### PR TITLE
Refactor: Improve naming conventions for clarity and consistency.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,31 @@
+export {
+  ESPDeviceConnection,
+  createESPDeviceConnection,
+  requestESPDevicePort,
+  attachSLIPEncoder,
+  createDeviceLogStreamReader,
+  createDeviceCommandStreamReader,
+  openESPDevicePort,
+  sendESPDeviceResetPulse,
+  writeToESPDevice,
+} from "./serial/serial-controller";
+
+export {
+  SLIPProtocolBytes,
+  DeviceLogTransformer,
+  DeviceDataTransformer,
+  DeviceLogLineBreakTransformer,
+  SLIPDataTransformer,
+  createDeviceLogTransformer,
+  createDeviceDataTransformer,
+  createDeviceLogLineBreakTransformer,
+  SLIPDataEncoder,
+  SLIPDataDecoder,
+} from "./serial/stream-transformers";
+
+export { calculateCRC32 } from "./utils/crc32";
+
+export { getChipFamilyName } from "./utils/chip-id";
+export { ESPLoader, ESPLoaderError, ROM_BAUD_RATE } from "./esploader";
+export { ESPStubLoader, ESP_ROM_BAUD_RATE } from "./esp_stub_loader";
+export { sleep } from "./utils/common";

--- a/src/utils/crc32.test.ts
+++ b/src/utils/crc32.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { crc32 } from "./crc32";
+import { calculateCRC32 } from "./crc32";
 
-describe("crc32", () => {
+describe("calculateCRC32", () => {
   const textEncoder = new TextEncoder();
 
   it("should compute the correct CRC32 for an empty buffer", () => {
     const input = new Uint8Array([]);
     const expected = new Uint8Array([0, 0, 0, 0]);
-    const result = crc32(input);
+    const result = calculateCRC32(input);
     expect(result).toEqual(expected);
   });
 
@@ -15,7 +15,7 @@ describe("crc32", () => {
     const input = textEncoder.encode("hello world");
     // CRC32 for "hello world" is 0x0d4a1185
     const expected = new Uint8Array([0x85, 0x11, 0x4a, 0x0d]);
-    const result = crc32(input);
+    const result = calculateCRC32(input);
     expect(result).toEqual(expected);
   });
 
@@ -23,7 +23,7 @@ describe("crc32", () => {
     const input = textEncoder.encode("123456789");
     // CRC32 for "123456789" is 0xcbf43926
     const expected = new Uint8Array([0x26, 0x39, 0xf4, 0xcb]);
-    const result = crc32(input);
+    const result = calculateCRC32(input);
     expect(result).toEqual(expected);
   });
 
@@ -33,7 +33,7 @@ describe("crc32", () => {
     );
     // CRC32 for this string is 0x414fa339
     const expected = new Uint8Array([0x39, 0xa3, 0x4f, 0x41]);
-    const result = crc32(input);
+    const result = calculateCRC32(input);
     expect(result).toEqual(expected);
   });
 
@@ -43,7 +43,7 @@ describe("crc32", () => {
     ]);
     // The correct CRC32 for this buffer is 0xb3fcc8eb
     const expected = new Uint8Array([0xeb, 0xc8, 0xfc, 0xb3]);
-    const result = crc32(input);
+    const result = calculateCRC32(input);
     expect(result).toEqual(expected);
   });
 
@@ -51,7 +51,7 @@ describe("crc32", () => {
     const input = textEncoder.encode("short"); // length 5
     // The correct CRC32 for "short" is 0x8f2890a2
     const expected = new Uint8Array([0xa2, 0x90, 0x28, 0x8f]);
-    const result = crc32(input);
+    const result = calculateCRC32(input);
     expect(result).toEqual(expected);
   });
 });

--- a/src/utils/crc32.ts
+++ b/src/utils/crc32.ts
@@ -3,7 +3,7 @@
  * Licenced under Apache 2.0, Copyright: 2015-2016 Espressif Systems (Shanghai) PTE LTD
  * Removed L notation from all entries.
  */
-const crc32Table: number[] = [
+const CRC32_LOOKUP_TABLE: number[] = [
   0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
   0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
   0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91, 0x1db71064, 0x6ab020f2,
@@ -58,12 +58,12 @@ const crc32Table: number[] = [
  * @param seed The initial CRC value. Defaults to 0xFFFFFFFF.
  * @returns A 4-byte Uint8Array representing the CRC32 checksum in little-endian order.
  */
-export function crc32(buf: Uint8Array, seed = 0xffffffff): Uint8Array {
+export function calculateCRC32(buf: Uint8Array, seed = 0xffffffff): Uint8Array {
   // For a standard single-table algorithm, the initial value C should be the seed itself.
   let C = seed;
 
   for (let i = 0; i < buf.length; ++i) {
-    C = (C >>> 8) ^ crc32Table[(C ^ buf[i]) & 0xff];
+    C = (C >>> 8) ^ CRC32_LOOKUP_TABLE[(C ^ buf[i]) & 0xff];
   }
 
   // The final post-inversion is part of the standard algorithm.


### PR DESCRIPTION
This commit refactors various identifiers across the codebase to improve clarity, descriptiveness, and consistency, aligning with the project's context of ESP device communication.

Key changes include:
- Renamed `SerialConnection` to `ESPDeviceConnection` and updated related function names in `serial-controller.ts`.
- Renamed stream transformer classes and functions in `stream-transformers.ts` to be more specific (e.g., `LoggingTransformer` to `DeviceLogTransformer`, `SlipStreamEncoder` to `SLIPDataEncoder`).
- Renamed `crc32` function to `calculateCRC32` and `crc32Table` to `CRC32_LOOKUP_TABLE` in `crc32.ts`.
- Updated `index.ts` to reflect these changes.
- Updated all affected test files to use the new names.

The goal of these changes is to make the codebase easier to understand for developers familiar with TypeScript and embedded systems. No functional changes have been made.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR